### PR TITLE
fix: prevent log spam when network is unavailable

### DIFF
--- a/src/main/lib/setup/playback.ts
+++ b/src/main/lib/setup/playback.ts
@@ -1,3 +1,4 @@
+import dns from 'dns'
 import { playbackManager } from '../playback/playback.js'
 import { getStorageValue } from '../storage.js'
 import { wss } from '../server.js'
@@ -8,7 +9,89 @@ import { SetupFunction } from '../../types/WebSocketSetup.js'
 
 export const name = 'playback'
 
+const MIN_RETRY_DELAY = 5000
+const MAX_RETRY_DELAY = 300000
+const NETWORK_CHECK_INTERVAL = 10000
+
+let currentRetryDelay = MIN_RETRY_DELAY
+let lastLogMessage = ''
+let lastLogTime = 0
+let reconnectTimeout: NodeJS.Timeout | null = null
+let networkCheckInterval: NodeJS.Timeout | null = null
+let isWaitingForNetwork = false
+
+function deduplicatedLog(message: string, scope: string): void {
+  const now = Date.now()
+  if (message === lastLogMessage && now - lastLogTime < 60000) {
+    return
+  }
+  lastLogMessage = message
+  lastLogTime = now
+  log(message, scope)
+}
+
+function checkNetworkConnectivity(): Promise<boolean> {
+  return new Promise(resolve => {
+    dns.lookup('spotify.com', err => {
+      resolve(!err)
+    })
+  })
+}
+
+async function attemptReconnect(playbackHandler: string): Promise<void> {
+  if (reconnectTimeout) {
+    clearTimeout(reconnectTimeout)
+    reconnectTimeout = null
+  }
+
+  const isOnline = await checkNetworkConnectivity()
+
+  if (!isOnline) {
+    if (!isWaitingForNetwork) {
+      deduplicatedLog(
+        'Network unavailable, waiting for connectivity...',
+        'PlaybackManager'
+      )
+      isWaitingForNetwork = true
+    }
+
+    if (!networkCheckInterval) {
+      networkCheckInterval = setInterval(async () => {
+        const online = await checkNetworkConnectivity()
+        if (online) {
+          if (networkCheckInterval) {
+            clearInterval(networkCheckInterval)
+            networkCheckInterval = null
+          }
+          isWaitingForNetwork = false
+          currentRetryDelay = MIN_RETRY_DELAY
+          deduplicatedLog(
+            'Network restored, reconnecting...',
+            'PlaybackManager'
+          )
+          await playbackManager.setup(playbackHandler)
+        }
+      }, NETWORK_CHECK_INTERVAL)
+    }
+    return
+  }
+
+  isWaitingForNetwork = false
+  deduplicatedLog(
+    `Attempting to reconnect in ${currentRetryDelay / 1000}s...`,
+    'PlaybackManager'
+  )
+
+  reconnectTimeout = setTimeout(async () => {
+    await playbackManager.setup(playbackHandler)
+  }, currentRetryDelay)
+
+  currentRetryDelay = Math.min(currentRetryDelay * 2, MAX_RETRY_DELAY)
+}
+
 export const setup: SetupFunction = async () => {
+  const playbackHandler = getStorageValue('playbackHandler')
+
   playbackManager.on('playback', data => {
     if (!wss) return
     wss.clients.forEach(async (ws: AuthenticatedWebSocket) => {
@@ -19,23 +102,20 @@ export const setup: SetupFunction = async () => {
   })
 
   playbackManager.on('close', async () => {
-    log('Closed, attempting to reopen in 5 seconds...', 'PlaybackManager')
+    deduplicatedLog('Connection closed', 'PlaybackManager')
     await playbackManager.cleanup()
-
-    setTimeout(async () => {
-      await playbackManager.setup(playbackHandler)
-    }, 5000)
+    await attemptReconnect(playbackHandler)
   })
 
   playbackManager.on('open', (handlerName?: string) => {
+    currentRetryDelay = MIN_RETRY_DELAY
     log(`Opened with handler ${handlerName}`, 'PlaybackManager')
   })
 
   playbackManager.on('error', err => {
-    log(`An error occurred: ${err}`, 'PlaybackManager')
+    const errorMessage = err instanceof Error ? err.message : String(err)
+    deduplicatedLog(`Error: ${errorMessage}`, 'PlaybackManager')
   })
-
-  const playbackHandler = getStorageValue('playbackHandler')
 
   if (!playbackHandler || playbackHandler === 'none') {
     log('No handler set', 'Playback')
@@ -44,6 +124,14 @@ export const setup: SetupFunction = async () => {
   }
 
   return async () => {
+    if (reconnectTimeout) {
+      clearTimeout(reconnectTimeout)
+      reconnectTimeout = null
+    }
+    if (networkCheckInterval) {
+      clearInterval(networkCheckInterval)
+      networkCheckInterval = null
+    }
     await playbackManager.cleanup()
     playbackManager.removeAllListeners()
   }

--- a/src/renderer/src/contexts/ChannelContext.tsx
+++ b/src/renderer/src/contexts/ChannelContext.tsx
@@ -1,7 +1,7 @@
 import { createContext, useEffect, useState } from 'react'
 
 interface ChannelContextType {
-  channel: "stable" | "nightly" | null
+  channel: 'stable' | 'nightly' | null
 }
 
 const ChannelContext = createContext<ChannelContextType>({
@@ -15,7 +15,7 @@ interface ChannelContextProviderProps {
 const ChannelContextProvider = ({
   children
 }: ChannelContextProviderProps) => {
-  const [channel, setChannel] = useState<"stable" | "nightly" | null>(null)
+  const [channel, setChannel] = useState<'stable' | 'nightly' | null>(null)
 
   useEffect(() => {
     window.api.getChannel().then(setChannel)
@@ -24,7 +24,7 @@ const ChannelContextProvider = ({
   return (
     <ChannelContext.Provider
       value={{
-        channel,
+        channel
       }}
     >
       {children}


### PR DESCRIPTION
## Summary

Fixes #57 - Log file growing to 20GB+ when network is unavailable.

### Problem
When the network is unavailable, the app repeatedly tries to reconnect every 5 seconds, logging errors each time. This creates a flood of identical log messages that can grow the log file to 50GB+ in a week.

### Solution
- **Network connectivity check**: Before attempting reconnection, check if the network is available using DNS lookup
- **Exponential backoff**: Instead of fixed 5-second retry, use exponential backoff (5s → 10s → 20s... up to 5 minutes)
- **Log deduplication**: Skip logging identical messages within a 60-second window
- **Smart waiting**: When network is unavailable, wait silently and check every 10 seconds instead of repeatedly failing

### Behavior Change

**Before:**
```
[11:15:07] INFO <PlaybackManager>: Closed, attempting to reopen in 5 seconds...
[11:15:07] INFO <PlaybackManager>: An error occurred: Error: getaddrinfo ENOTFOUND dealer.spotify.com
[11:15:07] INFO <PlaybackManager>: Closed, attempting to reopen in 5 seconds...
[11:15:07] INFO <PlaybackManager>: An error occurred: Error: getaddrinfo ENOTFOUND dealer.spotify.com
... (repeats infinitely)
```

**After:**
```
[11:15:07] INFO <PlaybackManager>: Connection closed
[11:15:07] INFO <PlaybackManager>: Network unavailable, waiting for connectivity...
... (silent for 10 minutes while offline)
[11:25:07] INFO <PlaybackManager>: Network restored, reconnecting...
[11:25:08] INFO <PlaybackManager>: Opened with handler spotify
```

## Test Plan

- [x] Build succeeds (`npm run build`)
- [x] App starts normally with network available
- [x] When network disconnects, log shows "Network unavailable" once
- [x] When network reconnects, app reconnects automatically
- [x] Log file size stays reasonable during extended offline periods

---

This PR was created with AI assistance.

Made with [Cursor](https://cursor.com)