### PR TITLE
feat: support custom port in dev mode via PORT env var

### DIFF
--- a/src/main/lib/server.ts
+++ b/src/main/lib/server.ts
@@ -22,12 +22,15 @@ export async function getServerPort() {
   if (port) return port
 
   if (isDev()) {
-    if (await isPortOpen(1337)) {
-      port = 1337
+    const customPort = parseInt(process.env.PORT || '', 10)
+    const targetPort = !isNaN(customPort) ? customPort : 1337
+
+    if (await isPortOpen(targetPort)) {
+      port = targetPort
       return port
     } else {
       log(
-        'Port 1337 is already in use. Using a random available port instead.',
+        `Port ${targetPort} is already in use. Using a random available port instead.`,
         'WebSocketServer'
       )
     }


### PR DESCRIPTION
## Summary
Allows setting a custom port in development mode using the `PORT` environment variable.

## Problem
Closes #60 - Ability to set custom port in dev mode

## Solution
Instead of hardcoding port `1337` in dev mode, the `getServerPort` function now parses `process.env.PORT`. If it's valid, it uses that custom port, otherwise defaults to `1337`.

## Testing
- Built successfully: `npm run build`
- Verified server port config loads via environment variable

## Checklist
- [x] Code builds without errors
- [x] Dependencies added to package.json (none added)